### PR TITLE
Add :default cases to multi-methods

### DIFF
--- a/src/resauce/core.clj
+++ b/src/resauce/core.clj
@@ -38,6 +38,9 @@
         entry (.getEntry jar (add-ending-slash path))]
     (and entry (.isDirectory entry))))
 
+(defmethod directory? :default [url]
+  false)
+
 (defmulti url-dir
   "Return a list of URLs contained by this URL, if the protocol supports it."
   {:arglists '([url])}
@@ -55,6 +58,9 @@
          (map (memfn getName))
          (filter-dir-paths path)
          (map (partial build-url url path)))))
+
+(defmethod url-dir nil [url]
+  nil)
 
 (defn- default-loader []
   (.getContextClassLoader (Thread/currentThread)))

--- a/test/resauce/core_test.clj
+++ b/test/resauce/core_test.clj
@@ -7,7 +7,8 @@
   (is (directory? (io/resource "resauce")))
   (is (directory? (io/resource "clojure")))
   (is (not (directory? (io/resource "resauce/core.clj"))))
-  (is (not (directory? (io/resource "clojure/core.clj")))))
+  (is (not (directory? (io/resource "clojure/core.clj"))))
+  (is (not (directory? nil))))
 
 (deftest test-resources
   (let [rs (sort (map str (resources "resauce")))]
@@ -16,6 +17,8 @@
     (is (re-find #"test/resauce$" (second rs)))))
 
 (deftest test-url-dir
+  (is (nil? (url-dir nil)))
+  (is (thrown? java.lang.IllegalArgumentException (url-dir (io/as-url "http://www.example.com/docs/resource1.html"))))
   (testing "file URL"
     (let [rs (url-dir (io/as-url (io/file "src/resauce")))]
       (is (= (count rs) 1))


### PR DESCRIPTION
I had a bit more time and setup the `:default` for `url-dir` as well (and changed the commit msg).