### PR TITLE
Fix reflection warnings

### DIFF
--- a/src/resauce/core.clj
+++ b/src/resauce/core.clj
@@ -2,6 +2,7 @@
   (:require [clojure.java.io :as io])
   (:import [java.io File]
            [java.net JarURLConnection URI URL]
+           [java.util.jar JarEntry]
            [java.util.regex Pattern]))
 
 (defn- add-ending-slash [^String s]
@@ -20,8 +21,8 @@
   ;; Using URI instead of URL to support arguments without schema.
   (.getScheme (URI. (str url))))
 
-(defn- url-file [url]
-  (File. (.getPath (io/as-url url))))
+(defn- ^File url-file [url]
+  (File. ^String (.getPath (io/as-url url))))
 
 (defmulti directory?
   "Return true if a URL points to a directory resource."
@@ -56,7 +57,7 @@
         path (.getEntryName ^JarURLConnection conn)]
     (->> (.entries jar)
          (enumeration-seq)
-         (map (memfn getName))
+         (map (memfn ^JarEntry getName))
          (filter-dir-paths path)
          (map (partial build-url url path)))))
 


### PR DESCRIPTION
Hi James!

I've noticed the following lines in my app's logs while using `ragtime` for DB schema migrations:

```
Reflection warning, resauce/core.clj:35:10 - reference to field exists can't be resolved.
Reflection warning, resauce/core.clj:35:25 - reference to field isDirectory can't be resolved.
Reflection warning, resauce/core.clj:53:18 - reference to field listFiles can't be resolved.
Reflection warning, resauce/core.clj:61:15 - call to getName can't be resolved.
```

These reflective calls are unnecessary, so I've added explicit type hints in order to avoid them.

I guess, the "cherry on top" would be to bump the lib version and update `ragtime` dependency after this PR is merged.

Cheers,
Mark